### PR TITLE
Add animals module with custom entity

### DIFF
--- a/modules/custom/animals/animals.info.yml
+++ b/modules/custom/animals/animals.info.yml
@@ -1,0 +1,11 @@
+name: Animals
+type: module
+description: This module contains a custom entity called animal and other types of animals.
+core_version_requirement: ^9
+package: Custom
+dependencies:
+  - drupal:field
+  - drupal:paragraphs
+  - drupal:node
+  - drupal:taxonomy
+  - drupal:user

--- a/modules/custom/animals/animals.install
+++ b/modules/custom/animals/animals.install
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the animals module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function animals_install() {
+  // Create the animal entity type.
+  animals_create_animal_entity_type();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function animals_uninstall() {
+  // Delete the animal entity type.
+  \Drupal::entityTypeManager()->getStorage('animal')->delete();
+}
+
+/**
+ * Implements hook_update_N().
+ */
+function animals_update_8100() {
+  // Update the animal entity type.
+  animals_create_animal_entity_type();
+}
+
+/**
+ * Creates the animal entity type.
+ */
+function animals_create_animal_entity_type() {
+  $entity_type = \Drupal::entityTypeManager()->getDefinition('animal');
+  if (!$entity_type) {
+    $entity_type = \Drupal::entityTypeManager()->getStorage('entity_type')->create([
+      'id' => 'animal',
+      'label' => 'Animal',
+      'base_table' => 'animal',
+      'entity_keys' => [
+        'id' => 'id',
+        'label' => 'name',
+        'uuid' => 'uuid',
+      ],
+      'field_ui_base_route' => 'entity.animal.collection',
+    ]);
+    $entity_type->save();
+  }
+}

--- a/modules/custom/animals/animals.module
+++ b/modules/custom/animals/animals.module
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Contains animals.module.
+ */
+
+/**
+ * Implements hook_entity_type_build().
+ */
+function animals_entity_type_build(array &$entity_types) {
+  $entity_types['animal'] = \Drupal::entityTypeManager()->getDefinition('animal');
+}
+
+/**
+ * Implements hook_entity_bundle_info().
+ */
+function animals_entity_bundle_info(array &$bundles) {
+  $bundles['animal']['dog'] = [
+    'label' => t('Dog'),
+    'description' => t('A type of animal that is a dog.'),
+    'fields' => [
+      'dog_breed' => [
+        'type' => 'paragraph',
+        'label' => t('Dog Breed'),
+        'description' => t('The breed of the dog.'),
+        'settings' => [
+          'handler' => 'default:paragraph',
+          'handler_settings' => [
+            'target_bundles' => [
+              'dog_breed' => 'dog_breed',
+            ],
+          ],
+        ],
+      ],
+      'quantity' => [
+        'type' => 'integer',
+        'label' => t('Quantity'),
+        'description' => t('The quantity of the animal.'),
+        'settings' => [
+          'min' => 1,
+          'max' => 100,
+        ],
+      ],
+    ],
+  ];
+}

--- a/modules/custom/animals/animals.permissions.yml
+++ b/modules/custom/animals/animals.permissions.yml
@@ -1,0 +1,9 @@
+# Permissions for managing animal entities
+manage animal entities:
+  title: 'Manage animal entities'
+  description: 'Allows users to manage animal entities.'
+
+# Permissions for managing animal type entities
+manage animal type entities:
+  title: 'Manage animal type entities'
+  description: 'Allows users to manage animal type entities.'

--- a/modules/custom/animals/animals.routing.yml
+++ b/modules/custom/animals/animals.routing.yml
@@ -1,0 +1,51 @@
+animal.list:
+  path: '/animals'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalController::list'
+    _title: 'Animals'
+  requirements:
+    _permission: 'access content'
+
+animal.view:
+  path: '/animals/{animal}'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalController::view'
+    _title: 'View Animal'
+  requirements:
+    _permission: 'access content'
+    animal: \d+
+
+animal.delete:
+  path: '/animals/{animal}/delete'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalController::delete'
+    _title: 'Delete Animal'
+  requirements:
+    _permission: 'administer animals'
+    animal: \d+
+
+animal_type.list:
+  path: '/animal-types'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalTypeController::list'
+    _title: 'Animal Types'
+  requirements:
+    _permission: 'access content'
+
+animal_type.view:
+  path: '/animal-types/{animal_type}'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalTypeController::view'
+    _title: 'View Animal Type'
+  requirements:
+    _permission: 'access content'
+    animal_type: \d+
+
+animal_type.delete:
+  path: '/animal-types/{animal_type}/delete'
+  defaults:
+    _controller: '\Drupal\animals\Controller\AnimalTypeController::delete'
+    _title: 'Delete Animal Type'
+  requirements:
+    _permission: 'administer animal types'
+    animal_type: \d+

--- a/modules/custom/animals/src/Controller/AnimalController.php
+++ b/modules/custom/animals/src/Controller/AnimalController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\animals\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Class AnimalController.
+ *
+ * Provides route responses for the animal entity.
+ */
+class AnimalController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new AnimalController.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Lists all animal entities.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function list() {
+    $storage = $this->entityTypeManager->getStorage('animal');
+    $entities = $storage->loadMultiple();
+
+    $build = [
+      '#theme' => 'animal_list',
+      '#animals' => $entities,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Views an animal entity.
+   *
+   * @param int $animal
+   *   The animal entity ID.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function view($animal) {
+    $storage = $this->entityTypeManager->getStorage('animal');
+    $entity = $storage->load($animal);
+
+    $build = [
+      '#theme' => 'animal_view',
+      '#animal' => $entity,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Deletes an animal entity.
+   *
+   * @param int $animal
+   *   The animal entity ID.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response.
+   */
+  public function delete($animal) {
+    $storage = $this->entityTypeManager->getStorage('animal');
+    $entity = $storage->load($animal);
+    $entity->delete();
+
+    $this->messenger()->addStatus($this->t('The animal has been deleted.'));
+
+    return new RedirectResponse($this->url('entity.animal.collection'));
+  }
+
+}

--- a/modules/custom/animals/src/Controller/AnimalTypeController.php
+++ b/modules/custom/animals/src/Controller/AnimalTypeController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\animals\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Class AnimalTypeController.
+ *
+ * Provides route responses for the animal type entity.
+ */
+class AnimalTypeController extends ControllerBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new AnimalTypeController.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Lists all animal type entities.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function list() {
+    $storage = $this->entityTypeManager->getStorage('animal_type');
+    $entities = $storage->loadMultiple();
+
+    $build = [
+      '#theme' => 'animal_type_list',
+      '#animal_types' => $entities,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Views an animal type entity.
+   *
+   * @param int $animal_type
+   *   The animal type entity ID.
+   *
+   * @return array
+   *   A render array.
+   */
+  public function view($animal_type) {
+    $storage = $this->entityTypeManager->getStorage('animal_type');
+    $entity = $storage->load($animal_type);
+
+    $build = [
+      '#theme' => 'animal_type_view',
+      '#animal_type' => $entity,
+    ];
+
+    return $build;
+  }
+
+  /**
+   * Deletes an animal type entity.
+   *
+   * @param int $animal_type
+   *   The animal type entity ID.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   A redirect response.
+   */
+  public function delete($animal_type) {
+    $storage = $this->entityTypeManager->getStorage('animal_type');
+    $entity = $storage->load($animal_type);
+    $entity->delete();
+
+    $this->messenger()->addStatus($this->t('The animal type has been deleted.'));
+
+    return new RedirectResponse($this->url('entity.animal_type.collection'));
+  }
+
+}

--- a/modules/custom/animals/src/Entity/Animal.php
+++ b/modules/custom/animals/src/Entity/Animal.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\animals\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Defines the Animal entity.
+ *
+ * @ContentEntityType(
+ *   id = "animal",
+ *   label = @Translation("Animal"),
+ *   base_table = "animal",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "name",
+ *     "uuid" = "uuid"
+ *   },
+ *   field_ui_base_route = "entity.animal.collection"
+ * )
+ */
+class Animal extends ContentEntityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['name'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Name'))
+      ->setRequired(TRUE);
+
+    $fields['type'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Type'))
+      ->setRequired(TRUE)
+      ->setSettings([
+        'allowed_values' => [
+          'reptile' => 'Reptile',
+          'bird' => 'Bird',
+          'fish' => 'Fish',
+          'amphibian' => 'Amphibian',
+          'invertebrate' => 'Invertebrate',
+        ],
+      ]);
+
+    return $fields;
+  }
+
+}

--- a/modules/custom/animals/src/Entity/AnimalType.php
+++ b/modules/custom/animals/src/Entity/AnimalType.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\animals\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Defines the AnimalType entity.
+ *
+ * @ContentEntityType(
+ *   id = "animal_type",
+ *   label = @Translation("Animal Type"),
+ *   base_table = "animal_type",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "label" = "name",
+ *     "uuid" = "uuid"
+ *   },
+ *   field_ui_base_route = "entity.animal_type.collection"
+ * )
+ */
+class AnimalType extends ContentEntityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type) {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['dog_breed'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Dog Breed'))
+      ->setRequired(TRUE);
+
+    $fields['size'] = BaseFieldDefinition::create('list_string')
+      ->setLabel(t('Size'))
+      ->setRequired(TRUE)
+      ->setSettings([
+        'allowed_values' => [
+          'small' => 'Small',
+          'medium' => 'Medium',
+          'large' => 'Large',
+        ],
+      ]);
+
+    $fields['temperament'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Temperament'))
+      ->setRequired(TRUE);
+
+    $fields['lifespan'] = BaseFieldDefinition::create('integer')
+      ->setLabel(t('Lifespan'))
+      ->setRequired(TRUE);
+
+    $fields['origin'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Origin'))
+      ->setRequired(TRUE);
+
+    $fields['description'] = BaseFieldDefinition::create('text_long')
+      ->setLabel(t('Description'))
+      ->setRequired(TRUE);
+
+    return $fields;
+  }
+
+}

--- a/modules/custom/animals/src/Form/AnimalForm.php
+++ b/modules/custom/animals/src/Form/AnimalForm.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\animals\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form controller for the animal entity edit forms.
+ */
+class AnimalForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    /* @var \Drupal\animals\Entity\Animal $entity */
+    $form = parent::buildForm($form, $form_state);
+
+    $form['name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Name'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('name')->value,
+    ];
+
+    $form['type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Type'),
+      '#required' => TRUE,
+      '#options' => [
+        'reptile' => $this->t('Reptile'),
+        'bird' => $this->t('Bird'),
+        'fish' => $this->t('Fish'),
+        'amphibian' => $this->t('Amphibian'),
+        'invertebrate' => $this->t('Invertebrate'),
+      ],
+      '#default_value' => $this->entity->get('type')->value,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $status = parent::save($form, $form_state);
+
+    switch ($status) {
+      case SAVED_NEW:
+        $this->messenger()->addStatus($this->t('Created the %label Animal.', [
+          '%label' => $this->entity->label(),
+        ]));
+        break;
+
+      default:
+        $this->messenger()->addStatus($this->t('Saved the %label Animal.', [
+          '%label' => $this->entity->label(),
+        ]));
+    }
+
+    $form_state->setRedirect('entity.animal.canonical', ['animal' => $this->entity->id()]);
+  }
+
+}

--- a/modules/custom/animals/src/Form/AnimalTypeForm.php
+++ b/modules/custom/animals/src/Form/AnimalTypeForm.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\animals\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Form controller for the animal type entity edit forms.
+ */
+class AnimalTypeForm extends ContentEntityForm {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    /* @var \Drupal\animals\Entity\AnimalType $entity */
+    $form = parent::buildForm($form, $form_state);
+
+    $form['dog_breed'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Dog Breed'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('dog_breed')->value,
+    ];
+
+    $form['size'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Size'),
+      '#required' => TRUE,
+      '#options' => [
+        'small' => $this->t('Small'),
+        'medium' => $this->t('Medium'),
+        'large' => $this->t('Large'),
+      ],
+      '#default_value' => $this->entity->get('size')->value,
+    ];
+
+    $form['temperament'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Temperament'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('temperament')->value,
+    ];
+
+    $form['lifespan'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Lifespan'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('lifespan')->value,
+    ];
+
+    $form['origin'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Origin'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('origin')->value,
+    ];
+
+    $form['description'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Description'),
+      '#required' => TRUE,
+      '#default_value' => $this->entity->get('description')->value,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $status = parent::save($form, $form_state);
+
+    switch ($status) {
+      case SAVED_NEW:
+        $this->messenger()->addStatus($this->t('Created the %label Animal Type.', [
+          '%label' => $this->entity->label(),
+        ]));
+        break;
+
+      default:
+        $this->messenger()->addStatus($this->t('Saved the %label Animal Type.', [
+          '%label' => $this->entity->label(),
+        ]));
+    }
+
+    $form_state->setRedirect('entity.animal_type.canonical', ['animal_type' => $this->entity->id()]);
+  }
+
+}


### PR DESCRIPTION
Fixes #132

Add a new `animals` module with a custom entity called `animal` and a custom entity type `dog`.

* **Module Definition**
  - Add `animals.info.yml` to define the module with dependencies.
  - Add `animals.install` to handle installation, update, and uninstallation.
  - Add `animals.module` to define the animal entity type and dog bundle.

* **Entity Definitions**
  - Add `Animal.php` to define the `animal` entity with base fields `name` and `type`.
  - Add `AnimalType.php` to define the `animal_type` entity with fields for dog breed, size, temperament, lifespan, origin, and description.

* **Forms**
  - Add `AnimalForm.php` to handle the creation and editing of animal entities.
  - Add `AnimalTypeForm.php` to handle the creation and editing of animal type entities.

* **Controllers**
  - Add `AnimalController.php` to handle routes for listing, viewing, and deleting animal entities.
  - Add `AnimalTypeController.php` to handle routes for listing, viewing, and deleting animal type entities.

* **Routing and Permissions**
  - Add `animals.routing.yml` to define routes for animal and animal type entity operations.
  - Add `animals.permissions.yml` to define permissions for managing animal and animal type entities.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ronaldtebrake/open_social/pull/133?shareId=4d085f94-84c6-4c60-8651-f1be16a1b00f).